### PR TITLE
Fixed data confusion on missing input fields

### DIFF
--- a/lib/Data/Transpose.pm
+++ b/lib/Data/Transpose.pm
@@ -196,7 +196,7 @@ sub transpose {
             $weed_value = $fld->value($vref->{$fld_name});
         }
         else {
-            $weed_value = $fld->value;
+            $weed_value = $fld->value(undef);
         }
 
         if ($new_name = $fld->target) {

--- a/lib/Data/Transpose/Group.pm
+++ b/lib/Data/Transpose/Group.pm
@@ -106,13 +106,19 @@ Returns value for output:
     
     $output = $group->value;
 
+With undefined argument, does not set the output to undef (because a
+group always output a string), but apply the joining.
+
+With a defined argument, does not perform the joining, but set the
+output value.
+
 =cut
 
 sub value {
     my $self = shift;
     my $token;
     
-    if (@_) {
+    if (@_ and defined($_[0])) {
         $self->_set__output(shift);
     }
     else {

--- a/t/undefined-fields.t
+++ b/t/undefined-fields.t
@@ -1,0 +1,53 @@
+#!perl
+
+use strict;
+use warnings;
+use utf8;
+use Data::Transpose;
+use Data::Dumper;
+use Test::More tests => 1;
+
+my @records = (
+               {
+                first => 'f',
+                second => 's',
+               },
+               {
+                first => 'f',
+               },
+               {
+                second => 'c',
+               },
+               {
+               },
+              );
+
+my $tp = Data::Transpose->new;
+
+$tp->field('first')->target('primo');
+$tp->field('second')->target('secondo');
+
+my @transposed;
+
+foreach my $r (@records) {
+    push @transposed, $tp->transpose($r);
+}
+
+is_deeply \@transposed, [
+                         {
+                          primo => 'f',
+                          secondo => 's',
+                         },
+                         {
+                          primo => 'f',
+                          secondo => undef,
+                         },
+                         {
+                          secondo => 'c',
+                          primo => undef,
+                         },
+                         {
+                          secondo => undef,
+                          primo => undef,
+                         },
+                        ];


### PR DESCRIPTION
The problem arise from the handling of ->value for Group and Field. Transpose call them transparently, but with or without argument they  do different things. This is the best I came up with.