### PR TITLE
Improve clarity in Data::Transpose::Validator::Subrefs POD

### DIFF
--- a/lib/Data/Transpose/Validator/Subrefs.pm
+++ b/lib/Data/Transpose/Validator/Subrefs.pm
@@ -30,8 +30,8 @@ Data::Transpose::Validator::Subrefs Validator using custom subroutines
 
 The constructor accepts only one argument, a reference to a
 subroutine. The class will provide the variable to validate as the
-first and only argument. The subroutine is expected to return the
-variable itself on success, or a false value.
+first and only argument. The subroutine is expected to return a
+true value on success, or a false value on failure.
 
 To set a custom error, the subroutine in case of error should return 2
 elements, where the first should be undefined (see the example above).


### PR DESCRIPTION
POD used to state that the value should be returned on success but in
fact the returned value must be truthy so returning a falsy value such
as zero caused validation to fail.