### PR TITLE
make EmailValid errors more helpful to end user

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,9 +12,11 @@ WriteMakefile(
       ? ('LICENSE'=> 'perl')
       : ()),
     PL_FILES            => {},
-    PREREQ_PM => {
+    BUILD_REQUIRES   => {
         'Test::More' => 0,
         'Test::Warn' => 0,
+    },
+    PREREQ_PM => {
         'Email::Valid' => 0,
         'Try::Tiny' => 0,
         'Module::Load' => 0,


### PR DESCRIPTION
Old errors are of the form 'mxcheck' or 'fqdn'. This commit adds the prefix 'Email address not valid: ' to the overly-terse errors.
