### PR TITLE
make EmailValid errors more useful to end user

### DIFF
--- a/lib/Data/Transpose/EmailValid.pm
+++ b/lib/Data/Transpose/EmailValid.pm
@@ -117,7 +117,7 @@ sub is_valid {
     # do validation
     $email = $self->_email_valid->address($email);
     unless ($email) {
-        $self->error($self->_email_valid->details);
+        $self->error("Email address not valid: " . $self->_email_valid->details);
         return;
     }
 

--- a/t/transpose-email.t
+++ b/t/transpose-email.t
@@ -40,7 +40,7 @@ while (my ($input, $output) = each %valid) {
 
 while (my ($input, $reason) = each %invalid) {
     ok(! $email->is_valid($input), "$input is invalid");
-    is($email->reason, $reason, "$input ($reason)");
+    like($email->reason, qr/$reason/, "$input ($reason)");
 }
 
 done_testing;

--- a/t/transpose-validation-forms.t
+++ b/t/transpose-validation-forms.t
@@ -168,7 +168,7 @@ test_form (
            form => {mail => "invalid+ciao\@asdf_daslf"},
            expected => {},
            message => "Invalid email",
-           error_hash => { mail => [ 'fqdn' ] },
+           error_hash => { mail => [ 'Email address not valid: fqdn' ] },
            fail => 1,
            debug => 0,
           );
@@ -181,7 +181,7 @@ test_form (
                    },
            expected => {},
            message => "Invalid email2",
-           error_hash => { mail2 => [ 'fqdn' ] },
+           error_hash => { mail2 => [ 'Email address not valid: fqdn' ] },
            fail => 1,
            debug => 0,
           );
@@ -195,7 +195,7 @@ test_form (
                    },
            expected => {},
            message => "Invalid email2",
-           error_hash => { mail2 => [ 'mxcheck' ] },
+           error_hash => { mail2 => [ 'Email address not valid: mxcheck' ] },
            fail => 1,
            debug => 0,
           );


### PR DESCRIPTION
Old errors are of the form 'mxcheck' or 'fqdn'. This commit adds the prefix 'Email address not valid: ' to the overly-terse errors.